### PR TITLE
Fixed link to haskell wiki.

### DIFF
--- a/src/Control/Monad/Supply.hs
+++ b/src/Control/Monad/Supply.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 
 -- | Support for computations which consume values from a (possibly infinite)
--- supply. See http://www.haskell.org/haskellwiki/New_monads/MonadSupply for
+-- supply. See <http://www.haskell.org/haskellwiki/New_monads/MonadSupply> for
 -- details.
 module Control.Monad.Supply
 ( MonadSupply (..)


### PR DESCRIPTION
Wrapped the MonadSupply link in '<' '>' to get haddock to automatically
generate a hyperlink to the page.
