### PR TITLE
Proposed fix to https://github.com/ghulette/monad-supply/issues/9

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+0.8: To fix MonadFail issue for GHC >= 8.6, runSupply and evalSupply are changed to return Maybe types.
+
 0.7: Semigroup instances.
 
 0.6: Reverted to Control.Monad.Error -- yields deprecation warnings but there is nothing to be done about it, yet.

--- a/monad-supply.cabal
+++ b/monad-supply.cabal
@@ -1,6 +1,6 @@
 Name:          monad-supply
 Build-type:    Simple
-Version:       0.7
+Version:       0.8
 Cabal-Version: >= 1.6
 Synopsis:      Stateful supply monad.
 Description:   Support for computations which consume values from a (possibly infinite) supply.

--- a/monad-supply.cabal
+++ b/monad-supply.cabal
@@ -16,7 +16,8 @@ Library
   Exposed-modules: Control.Monad.Supply
   Hs-Source-Dirs:  src
   Build-Depends:   base >= 4 && < 5,
-                   mtl >= 2
+                   mtl >= 2,
+                   transformers >= 0.5
   GHC-Options:     -Wall
 
 Source-Repository head


### PR DESCRIPTION
- Change `MonadSupply` to be a subclass of `MonadFail`. 
- `Maybe` is used as base monad for `Supply`, instead of `Identity`.
- Class interface of `MonadSupply` remains the same, but `runSupply` and `evalSupply` return `Maybe` types. 

What do you think?